### PR TITLE
Log synchronously

### DIFF
--- a/bin/wait-for-socket
+++ b/bin/wait-for-socket
@@ -10,6 +10,7 @@ Clamp do
   option "--port", "<port>", "the port number to monitor", required: true
 
   def execute
+    $stdout.sync = true
     puts "Waiting for #{description} to become available at #{address}:#{port_int}"
     loop do
       if socket_reachable?(address, port_int)


### PR DESCRIPTION
When run from Foreman, the 'Waiting' message is buffered, and not output until the socket is ready. This change makes the logging be output synchronously so it will always show up straight away, so you know what you're waiting for.

```bash
gem install foreman
echo "myapp: sh -c './bin/wait-for-socket --description myapp --address localhost --port 3000 && sleep 99999'" > Procfile
foreman start
```

While waiting:

```
➜ foreman start
20:25:55 myapp.1 | started with pid 1015162
```

When ready:

```
➜ foreman start
20:25:55 myapp.1 | started with pid 1015162
20:26:05 myapp.1 | .....Waiting for myapp to become available at localhost:3000
20:26:05 myapp.1 |
20:26:05 myapp.1 | myapp ready
```

While waiting:

```
➜ foreman start
20:27:06 myapp.1 | started with pid 1017254
20:27:06 myapp.1 | Waiting for myapp to become available at localhost:3000
```

When ready:

```
➜ foreman start
20:27:06 myapp.1 | started with pid 1017254
20:27:06 myapp.1 | Waiting for myapp to become available at localhost:3000
20:27:22 myapp.1 | ........
20:27:22 myapp.1 | myapp ready
```

The dots still don't show up until it's ready, but that's expected, since Foreman can only output a line when it's a full line (ending with "\n").