### PR TITLE
Use Integer as block for port coercion and validation

### DIFF
--- a/bin/wait-for-socket
+++ b/bin/wait-for-socket
@@ -7,14 +7,14 @@ Clamp do
 
   option %w[--description -d], "<service name>", "description of the service we're waiting for", required: true
   option %w[--address -a], "<host or IP>", "the hostname or IP to monitor", required: true
-  option %w[--port -p], "<port>", "the port number to monitor", required: true
+  option %w[--port -p], "<port>", "the port number to monitor", required: true, &method(:Integer)
   option %w[--interval -i], "<seconds>", "the number of seconds to wait between polling attempts", default: 2, &method(:Float)
 
   def execute
     $stdout.sync = true
     puts "Waiting for #{description} to become available at #{address}:#{port_int}"
     loop do
-      if socket_reachable?(address, port_int)
+      if socket_reachable?(address, port)
         puts
         puts "#{description} ready"
         break
@@ -26,10 +26,6 @@ Clamp do
   end
 
   private
-
-  def port_int
-    port.to_i
-  end
 
   def socket_reachable?(hostname, port)
     Socket.tcp(hostname, port, connect_timeout: 2) {}


### PR DESCRIPTION
This is briefer than the manual coercion. Not that `Socket.tcp` seems to need it anyway..?

It also adds validation that the port is indeed an integer:

```
➜ ./bin/wait-for-socket --description myapp --address localhost --port 3000x
ERROR: option '--port': invalid value for Integer(): "3000x"

See: 'wait-for-socket --help'
```